### PR TITLE
Segment.io installation

### DIFF
--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -34,7 +34,16 @@
       document.getElementById('mobile-shade').addEventListener('click', function () {
         document.body.classList.remove('sidebar-open')
       })
+     <% if (config.apis.ga) { %>
+        // Google analytics
+        ;(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+        ga('create', '<%- config.apis.ga %>', 'auto');
+        ga('send', 'pageview');
+      <% } %>
       <% if (config.apis.segment) { %>
         // Segment Tracking
         !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.1.0";

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -35,39 +35,12 @@
         document.body.classList.remove('sidebar-open')
       })
 
-      <% if (config.apis.ga) { %>
-        // Google analytics
-        ;(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-        ga('create', '<%- config.apis.ga %>', 'auto');
-        ga('send', 'pageview');
-      <% } %>
-
-      <% if (config.apis.marketo) { %>
-        // Marketo
-        (function() {
-          var didInit = false;
-          function initMunchkin() {
-            if(didInit === false) {
-              didInit = true;
-              Munchkin.init('<%- config.apis.marketo %>');
-            }
-          }
-          var s = document.createElement('script');
-          s.type = 'text/javascript';
-          s.async = true;
-          s.src = '//munchkin.marketo.net/munchkin.js';
-          s.onreadystatechange = function() {
-            if (this.readyState == 'complete' || this.readyState == 'loaded') {
-              initMunchkin();
-            }
-          };
-          s.onload = initMunchkin;
-          document.getElementsByTagName('head')[0].appendChild(s);
-        })();
+      <% if (config.apis.segment) { %>
+        // Segment Tracking
+        !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.1.0";
+        analytics.load("<%- config.apis.segment %>");
+        analytics.page()
+        }}();
       <% } %>
 
       // search box


### PR DESCRIPTION
This change enables Segment.io analytics on via this hero theme. Since we have been tracking the guide for a while on its own GA ID, I’m leaving GA in to ensure continuity. Marketo will be fired through Segment. 