### PR TITLE
Reduce visibility of "edit on Github" button

### DIFF
--- a/layout/page.ejs
+++ b/layout/page.ejs
@@ -56,7 +56,7 @@
 
       <div class="page-actions">
         <div class="actions-group">
-          <a class="btn primary small round lowercase" href="<%- githubUrl %>" target="_blank"><span class="icon-github"></span> <span>Edit on GitHub</span></a>
+          <a class="btn tertiary small round lowercase" href="<%- githubUrl %>" target="_blank"><span class="icon-github"></span> <span>Edit on GitHub</span></a>
           <% if (page.discourseTopicId) { %>
             <a class="btn tertiary small round lowercase" href="https://forums.meteor.com/t/<%- page.discourseTopicId %>"><span class="icon-comment"></span> <span>Discuss</span></a>
           <% } %>


### PR DESCRIPTION
When you visit a page in the documentation right now, the object on the page immediately attracting the most attention is "Edit on Github", which strikes me as not really the most important thing on the page compared to the likely actual documentation the user is seeking. This edit just reduces its visibility by making it grey rather than the red it was set to.
