### PR TITLE
Add zero-width space to empty lines in code blocks

### DIFF
--- a/source/style/_global/formatting.less
+++ b/source/style/_global/formatting.less
@@ -169,6 +169,10 @@
 		    padding: @spacing 15px @spacing 20px;
 				margin: 0;
 				white-space: pre;
+
+				// Make sure that empty lines don't collapse to zero height by
+				// inserting a zero-width space.
+				.line:empty::after { content: '\200b'; }
 		  }
 		}
 	}


### PR DESCRIPTION
Without additional content or a fixed height, empty lines in code blocks collapse to zero height and are not aligned with the line numbers anymore.

Before:
![docs1](https://cloud.githubusercontent.com/assets/1312807/19450062/445f5a64-94a8-11e6-9882-075e40a08ab8.png)

After:
![docs2](https://cloud.githubusercontent.com/assets/1312807/19450087/4905b8c4-94a8-11e6-8375-d52c1bb73165.png)

Tested with Chrome, Firefox, and Safari.
