### PR TITLE
Upgrade Algolia docsearch.js from ^1.0.0 to 2.1.8 to fix 100% CPU

### DIFF
--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -30,7 +30,7 @@
     <%- body %>
     <script src="<%= config.root || '/' %>script/smooth-scroll.min.js"></script>
     <script src="<%= config.root || '/' %>script/main.js"></script>
-    <script type="text/javascript" src="//cdn.jsdelivr.net/docsearch.js/1/docsearch.min.js"></script>
+    <script type="text/javascript" src="//cdn.jsdelivr.net/docsearch.js/2.1.8/docsearch.min.js"></script>
     <script type="text/javascript" src="//cdn.jsdelivr.net/fastclick/1.0.6/fastclick.min.js"></script>
 
     <script>


### PR DESCRIPTION
Currently, guide.meteor.com and docs.meteor.com are both using 100% CPU whent the docsearch.js `script` tag is even loaded on the page, irregardless of whether or not the search is enabled.  This leads me to believe it's doing some sort of indexing or othe bizarre behavior.

This also happens on the latest ^2.0.0 release, however if I rolled back to 2.1.8 it worked properly.  Therefore, I've pinned the version to 2.1.8.

I'm not going to investigate further at this time.

Fixes: https://github.com/meteor/guide/issues/607