### PR TITLE
Remove .ellipsized mixin from the code style to fix code wrapping issue

### DIFF
--- a/source/style/_global/formatting.less
+++ b/source/style/_global/formatting.less
@@ -137,7 +137,6 @@
     margin-bottom: @spacing/2;
 
     code {
-      .ellipsized;
       border: none;
       box-shadow: none;
       color: @color-darkest;


### PR DESCRIPTION
The `.ellipsized` mixin is adding a `white-space: nowrap` and since it's used in the `code` block.  A `white-space: pre` would fix this as well, but it would have to be `!important` to take effect.

While `.ellipsized` adds some attractive shortening of code lines in the docs on smaller devices, it's not really helpful to the developer viewing the code as you can't "expand it" to see the code (something you probably need, as a developer). Also, it fixes this problem. :)

Fixes: https://github.com/meteor/docs/issues/93