### PR TITLE
Escape sidebar nested link html content

### DIFF
--- a/source/script/main.js
+++ b/source/script/main.js
@@ -6,6 +6,18 @@
   var activeLink = document.querySelector('.sidebar-link.current')
   var allLinks = []
 
+  var escapeEntityMap = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+  }
+
+  function escapeHtml(string) {
+    return String(string).replace(/[&<>]/g, function(s) {
+      return escapeEntityMap[s];
+    });
+  }
+
   // create sub links for h2s
   var h2s = document.querySelectorAll('h2')
 
@@ -61,7 +73,7 @@
     allLinks.push(h)
     var headerLink = document.createElement('li')
     headerLink.innerHTML =
-      '<a href="#' + h.id + '" data-scroll class="' + h.tagName + '"><span>' + (h.title || h.textContent) + '</span></a>'
+      '<a href="#' + h.id + '" data-scroll class="' + h.tagName + '"><span>' + escapeHtml(h.title || h.textContent) + '</span></a>'
     headerLink.firstChild.addEventListener('click', onLinkClick)
     return headerLink
   }


### PR DESCRIPTION
This fixes an issue found in https://github.com/apollographql/react-docs/pull/166 where we want to use a React component as a header: `<ApolloProvider client={client} />`. However, because we don’t escape HTML tags in sidebar items the browser ends up interpreting the header as if it were an HTML element! This should fix that be escaping HTML in nested link headers.

cc @stubailo, @helfer, @tmeasday