### PR TITLE
Style <em> as italic everywhere.

### DIFF
--- a/source/style/_theme/content.less
+++ b/source/style/_theme/content.less
@@ -46,6 +46,10 @@
     }
   }
 
+  em {
+    .type-italic;
+  }
+
   .api {
     .font-s3;
     background: @color-lightest;
@@ -72,10 +76,6 @@
 
         .anchor {
           display: none;
-        }
-
-        em {
-          .type-italic;
         }
       }
 


### PR DESCRIPTION
Across our Hexo-powered sites, using `_empasis_` syntax in Markdown produces `<em>emphasis</em>`, which should be italicized, but isn't. There's no other option for italics as far as I can tell, since `*emphasis*` and `**emphasis**` both bold the word without italicizing it.