### PR TITLE
Introduce theme-specific CSS bundles.

### DIFF
--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -35,7 +35,11 @@
     <!-- Misc -->
     <meta name="google-site-verification" content="" />
     <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,200,300italic,400italic' rel='stylesheet' type='text/css'>
-    <link rel="stylesheet" href="<%= url_for('style/style.css', { relative: true }) %>">
+    <% if (config.css_bundle) {  %>
+      <link rel="stylesheet" href="<%= url_for('style/bundle-' + config.css_bundle + '.css', { relative: true }) %>">
+    <% } else { %>
+      <link rel="stylesheet" href="<%= url_for('style/style.css', { relative: true }) %>">
+    <% } %>
   </head>
   <body class="">
     <% if (config.apis && config.apis.gtm) { %>

--- a/source/style/_common-post.less
+++ b/source/style/_common-post.less
@@ -1,0 +1,30 @@
+// Overrides specified by the user
+@import '../../../../assets/theme-colors.less';
+
+// global namespace
+@import './_global/animation.less';
+@import './_global/base.less';
+@import './_global/button.less';
+@import './_global/docsearch.less';
+@import './_global/formatting.less';
+@import './_global/Textarea.less';
+@import './_global/form.less';
+@import './_global/Input.less';
+@import './_global/Radio.less';
+@import './_global/Checkbox.less';
+@import './_global/Select.less';
+@import './_global/icon.less';
+@import './_global/link.less';
+@import './_global/mobile.less';
+@import './_global/nav.less';
+@import './_global/panel.less';
+@import './_global/syntax.less';
+
+
+// global templates
+@import './_theme/layout.less';
+@import './_theme/panel.less';
+@import './_theme/sidebar.less';
+@import './_theme/content.less';
+@import './_theme/nav.less';
+@import './_theme/colors.less';

--- a/source/style/_common-pre.less
+++ b/source/style/_common-pre.less
@@ -1,0 +1,8 @@
+@import './_util/normalize.import.less';
+
+// Mixins, Utilities and Default colors.  It's important that this be
+// defined before other color overrides, such as variation-specific colors,
+// or deployment specific colors (those defined in ./assets/theme-colors.less
+// within the doc deployment root).
+
+@import './_util/index.import.less';

--- a/source/style/bundle-apollo.less
+++ b/source/style/bundle-apollo.less
@@ -1,0 +1,6 @@
+@import './_common-pre.less';
+
+// Indviduial color overrides for this variation go here.
+@color-primary: #22A699;
+
+@import './_common-post.less';

--- a/source/style/bundle-meteor.less
+++ b/source/style/bundle-meteor.less
@@ -1,0 +1,5 @@
+@import './_common-pre.less';
+
+// Indviduial color overrides for this variation go here.
+
+@import './_common-post.less';

--- a/source/style/style.less
+++ b/source/style/style.less
@@ -1,35 +1,7 @@
-@import './_util/normalize.import.less';
+// This file represents a legacy bundle which could be phased out.  This bundle
+// will still be used by the `layout/layout.ejs` template in this repository
+// in the event that the `css_variable_scope` variable is not defined in the
+// theme configuration.
 
-// Mixins & Utilities
-@import './_util/index.import.less';
-
-// Overrides specified by the user
-@import '../../../../assets/theme-colors.less';
-
-// global namespace
-@import './_global/animation.less';
-@import './_global/base.less';
-@import './_global/button.less';
-@import './_global/docsearch.less';
-@import './_global/formatting.less';
-@import './_global/Textarea.less';
-@import './_global/form.less';
-@import './_global/Input.less';
-@import './_global/Radio.less';
-@import './_global/Checkbox.less';
-@import './_global/Select.less';
-@import './_global/icon.less';
-@import './_global/link.less';
-@import './_global/mobile.less';
-@import './_global/nav.less';
-@import './_global/panel.less';
-@import './_global/syntax.less';
-
-
-// global templates
-@import './_theme/layout.less';
-@import './_theme/panel.less';
-@import './_theme/sidebar.less';
-@import './_theme/content.less';
-@import './_theme/nav.less';
-@import './_theme/colors.less';
+@import './_common-pre.less';
+@import './_common-post.less';


### PR DESCRIPTION
This introduces two separate CSS bundles, which are created automatically by Hexo, share almost 100% of their code, and are able to be selected by individual doc deployments by use of the `css_bundle` variable.  At a higher level, that variable will be automatically set through the `apollo-hexo-config`[0] and `meteor-hexo-config`[1] config packages, so no changes by the individual deployments will be necessary.

This builds on the work done in the Apollo/Meteor theme merge[2], and eliminates a local `./assets/theme-colors.less` which was still present in each Apollo docs deployment.

In additional to being a maintenance burden in the event that we wanted to change that file, it was also the source of problems with link colors exhibited in the test theme used on the Netlify previews on this `hexo-theme-meteor` repository.

This eliminates the need for that file (though keeps it there in case the need arises for a _deployment-specific_ color override.

[0] https://github.com/apollographql/apollo-hexo-config
[1] https://github.com/meteor/meteor-hexo-config
[2] https://github.com/meteor/hexo-theme-meteor/pull/51

cc @stubailo tl;dr fyi, red link colors fixed. was unnoticed bug-ish. :tada:.