### PR TITLE
Enlarge menu icon touch area and reduce nearby touch interference.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## vNEXT
 
 * The `versions` property is no longer mandatory in `_config.yml` configurations.
+* mobile: The menu button no longer necessitates the use of the pinky finger to reliably expand and contract it.
 
 ## v1.0.3
 

--- a/layout/page.ejs
+++ b/layout/page.ejs
@@ -4,10 +4,8 @@
 
   <div class="nav <%- config.nav_class %>">
     <div class="nav-group left">
-      <div class="nav-item mobile-button show-mobile">
-        <span class="js-sidebar-toggle ">
-          <span class="icon-menu"></span>
-        </span>
+      <div class="nav-item mobile-button js-sidebar-toggle show-mobile">
+        <span class="icon-menu"></span>
       </div>
       <div class="nav-item">
         <% logo = config.logo || theme.logo %>

--- a/source/style/_global/nav.less
+++ b/source/style/_global/nav.less
@@ -26,10 +26,6 @@ nav {
 		display: inline-block;
 		line-height: 3rem;
 	}
-
-	.mobile-button {
-		margin-right: 0.75rem;
-	}
 }
 
 .nav {
@@ -97,6 +93,10 @@ nav {
     .position(absolute, .5rem, auto, auto, 0);
 		.std-xpadding;
     z-index: 1;
+
+    .nav-item.mobile-button:first-child {
+      padding-right: 0.75rem;
+    }
 
     &.right {
       left: auto;

--- a/source/style/_theme/colors.less
+++ b/source/style/_theme/colors.less
@@ -159,10 +159,6 @@
     svg {
       fill: @color-lightest;
     }
-    .nav-item {
-      padding-bottom: 1.25rem;
-    }
-
     .popup {
       background-image: linear-gradient(180deg, #516fad 4%, #3b5a9e 97%);
       padding: 0;
@@ -194,9 +190,6 @@
     }
     svg {
       fill: @color-lightest;
-    }
-    .nav-item {
-      padding-bottom: 1.25rem;
     }
 
     .popup {


### PR DESCRIPTION
Currently on mobile, clicking the menu button to pop-out the menu is
quite difficult due to the small touch target by the "icon-menu" span.

This changes the click target to be the `div` parent of that `span`, and
uses `padding` (which has touch events) rather than `margin` which is
outside the touch area in the box-model.

Additionally, fixes the bottom-padding on the `nav-item` which was
interfering with navigation elements below it.

This padding on the `nav-item` once affected the menu button (on the left in
mobile) AND the bottom of the nav menu links on the right (in desktop view).

Now that the header is no longer used in this theme, the left menu button in
mobile is the only place this padding is observed and it has a negative
side-effect (since padding receives touch events in the box model) of blocking
touch events to the sidebar menu items.

This removes it and overall makes the menu clickable in mobile again.

Closes https://github.com/meteor/hexo-theme-meteor/issues/35.